### PR TITLE
Update PHP syntax check to exclude vendor directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: composer install --no-progress --no-suggest --prefer-dist
 
     - name: Check PHP syntax
-      run: find . -type f -name "*.php" -exec php -l {} \;
+      run: find . -type f -name "*.php" -not -path "./vendor/*" -exec php -l {} \;
 
     - name: PHP CodeSniffer
       run: ./vendor/bin/phpcs --standard=PSR12 src/


### PR DESCRIPTION
This pull request updates the PHP syntax check in the CI workflow to exclude the vendor directory. This ensures that only the project's source code is checked for syntax errors, improving the efficiency of the check.